### PR TITLE
Fetch license info in El-MAVEN

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ var public_token_header = '';
 var jwt_decode = require('jwt-decode');
 var DNS = require('dns')
 var appNames = {"FirstView": "firstview", 
-                "PollyPhi": "lcms_relative_elmaven", 
-                "QuantFit": "calibration_file_uploader_beta"};
+                "PollyPhi": "relative_lcms_elmaven", 
+                "QuantFit": "calibration"};
 
 module.exports.hello = function() {
     console.log(chalk.green.bold("Hello from the other side! :) "));
@@ -276,14 +276,17 @@ module.exports.fetchAppLicense = function(token_filename) {
 
 }
 
-module.exports.createWorkflowRequest = function (token_filename, project_id) {
+module.exports.createWorkflowRequest = function (token_filename, 
+                                                 project_id,
+                                                 workflow_name,
+                                                 workflow_id) {
     if (has_id_token(token_filename)) {
         public_token_header = read_id_token(token_filename);
     }
     var payload = {
         "workflow_details":{
-            "workflow_name": "relative_lcms_elmaven",
-            "workflow_id": 4 //get workflow id
+            "workflow_name": workflow_name,
+            "workflow_id": workflow_id
         },
         "name": "PollyPhi™ Relative LCMS El-MAVEN Untitled",
         "project_id": project_id
@@ -373,6 +376,40 @@ module.exports.getComponentId = function (token_filename) {
     var options = {
         method: 'GET',
         url: 'https://testpolly.elucidata.io/api/component',
+        headers:
+            {
+                'cache-control': 'no-cache',
+                'content-type': 'application/json',
+                'public-token': public_token_header
+            },
+        qs:
+            {
+            },
+        json: true
+    };
+
+    request(options, function (error, response, body) {
+        if (error) throw new Error(chalk.bold.red(error));
+        console.log(chalk.yellow.bgBlack.bold(`PostRun Response: `));
+        if (response.statusCode != 200) {
+            console.log(chalk.red.bold("Unable to get component IDs.",
+                                       "An unexpected error occurred.",
+                                       "Status code:"));
+            console.log(chalk.red.bold(response.statusCode));
+            return;
+        }
+        console.log(chalk.green.bold(JSON.stringify(body)));
+        return body
+    });
+}
+
+module.exports.getWorkflowId = function (token_filename) {
+    if (has_id_token(token_filename)) {
+        public_token_header = read_id_token(token_filename);
+    }
+    var options = {
+        method: 'GET',
+        url: 'https://testpolly.elucidata.io/api/wf-fe-info',
         headers:
             {
                 'cache-control': 'no-cache',

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var public_token_header = '';
 var jwt_decode = require('jwt-decode');
 var DNS = require('dns')
 var appNames = {"FirstView": "firstview", 
-                "PollyPhi": "lcms_tstpl_pvd", 
+                "PollyPhi": "lcms_relative_elmaven", 
                 "QuantFit": "calibration_file_uploader_beta"};
 
 module.exports.hello = function() {
@@ -360,6 +360,10 @@ module.exports.createRunRequest = function (token_filename, component_id, projec
         console.log(chalk.green.bold(JSON.stringify(body)));
         return body
     });
+}
+
+module.exports.getComponentName = function (appName) {
+    console.log("appName: " + appNames[appName]);
 }
 
 module.exports.getComponentId = function (token_filename) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ var AmazonCognitoIdentity = require('amazon-cognito-identity-js');
 var public_token_header = '';
 var jwt_decode = require('jwt-decode');
 var DNS = require('dns')
+var appNames = {"FirstView": "firstview", 
+                "PollyPhi": "lcms_tstpl_pvd", 
+                "QuantFit": "calibration_file_uploader_beta"};
+
 module.exports.hello = function() {
     console.log(chalk.green.bold("Hello from the other side! :) "));
 }


### PR DESCRIPTION
- Storing app and component/workflow name mapping
- Update APIs
- Return a list of active components, workflows and whether a license is active
- Currently fetching the first license from api/me
- Remove hardcoded workflow/component ids. Fetch them dynamically
- Stop sending API arguments in the body