### PR TITLE
[RFC]: Upload large files to S3

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -598,7 +598,9 @@ module.exports.uploadCuratedPeakDataToCloud = function (signed_url, filePath) {
             {
                 'x-amz-acl': 'bucket-owner-full-control',                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {
@@ -789,7 +791,9 @@ module.exports.createPutRequest = function (token_filename,url, filePath) {
                 'content-type': 'application/x-www-form-urlencoded',
                 'public-token': public_token_header                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {
@@ -812,7 +816,9 @@ module.exports.upload_project_data = function (url, filePath) {
             {
                 'x-amz-acl': 'bucket-owner-full-control',                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {

--- a/prod/index.js
+++ b/prod/index.js
@@ -598,7 +598,9 @@ module.exports.uploadCuratedPeakDataToCloud = function (signed_url, filePath) {
             {
                 'x-amz-acl': 'bucket-owner-full-control',                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {
@@ -789,7 +791,9 @@ module.exports.createPutRequest = function (token_filename,url, filePath) {
                 'content-type': 'application/x-www-form-urlencoded',
                 'public-token': public_token_header                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {
@@ -812,7 +816,9 @@ module.exports.upload_project_data = function (url, filePath) {
             {
                 'x-amz-acl': 'bucket-owner-full-control',                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {

--- a/test/index.js
+++ b/test/index.js
@@ -599,7 +599,9 @@ module.exports.uploadCuratedPeakDataToCloud = function (signed_url, filePath) {
             {
                 'x-amz-acl': 'bucket-owner-full-control',                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {
@@ -790,7 +792,9 @@ module.exports.createPutRequest = function (token_filename,url, filePath) {
                 'content-type': 'application/x-www-form-urlencoded',
                 'public-token': public_token_header                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {
@@ -813,7 +817,9 @@ module.exports.upload_project_data = function (url, filePath) {
             {
                 'x-amz-acl': 'bucket-owner-full-control',                
             },
-        body: fs.readFileSync(filePath)
+        formData: {
+            file: fs.createReadStream(filePath)
+        }
     };
 
     request(options, function (error, response, body) {


### PR DESCRIPTION
Previously, whole file was read and loaded into memory using **fs**. **fs** has a limitation of how many bytes can be read at max due to which very large files were not read and error was thrown.
Now, instead of loading whole file in the memory, file is read in chunks and uploaded to the s3 using **streams** in **fs**