### PR TITLE
[Fix] Stringify JS arrays for active licenses

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -278,9 +278,9 @@ module.exports.fetchAppLicense = function(token_filename) {
         }
 
         console.log("active components");
-        console.log(myComponents);
+        console.log(JSON.stringify(myComponents));
         console.log("active workflows");
-        console.log(myWorkflows);
+        console.log(JSON.stringify(myWorkflows));
         console.log("active license");
         console.log(activeLicense);
 

--- a/prod/index.js
+++ b/prod/index.js
@@ -278,9 +278,9 @@ module.exports.fetchAppLicense = function(token_filename) {
         }
 
         console.log("active components");
-        console.log(myComponents);
+        console.log(JSON.stringify(myComponents));
         console.log("active workflows");
-        console.log(myWorkflows);
+        console.log(JSON.stringify(myWorkflows));
         console.log("active license");
         console.log(activeLicense);
 

--- a/test/index.js
+++ b/test/index.js
@@ -278,9 +278,9 @@ module.exports.fetchAppLicense = function(token_filename) {
         }
 
         console.log("active components");
-        console.log(myComponents);
+        console.log(JSON.stringify(myComponents));
         console.log("active workflows");
-        console.log(myWorkflows);
+        console.log(JSON.stringify(myWorkflows));
         console.log("active license");
         console.log(activeLicense);
 


### PR DESCRIPTION
License arrays being sent from Polly's API will be wrapped within `JSON.stringify` methods. This ensures that regardless of the length of the array, the format remains the same (the entire array will be printed on a single line). It is good practice to stringify JS objects when logging to console as well as adheres to a format that El-MAVEN versions 0.7.1 and above expect from the API.