### PR TITLE
[Fix] DNS resolution for connectivity check

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -18,8 +18,8 @@ module.exports.hello = function() {
 
 module.exports.check_internet_connection = function(){
     // assuming google server will always be up.
-    DNS.resolve('www.google.com', function(err) {
-        if (err) {
+    DNS.lookup('www.google.com', function(err) {
+        if (err && err.code == "ENOTFOUND") {
             console.error("No Internet Connection");
         } else {
             console.log("Connected");

--- a/prod/index.js
+++ b/prod/index.js
@@ -18,8 +18,8 @@ module.exports.hello = function() {
 
 module.exports.check_internet_connection = function(){
     // assuming google server will always be up.
-    DNS.resolve('www.google.com', function(err) {
-        if (err) {
+    DNS.lookup('www.google.com', function(err) {
+        if (err && err.code == "ENOTFOUND") {
             console.error("No Internet Connection");
         } else {
             console.log("Connected");

--- a/test/index.js
+++ b/test/index.js
@@ -18,8 +18,8 @@ module.exports.hello = function() {
 
 module.exports.check_internet_connection = function(){
     // assuming google server will always be up.
-    DNS.resolve('www.google.com', function(err) {
-        if (err) {
+    DNS.lookup('www.google.com', function(err) {
+        if (err && err.code == "ENOTFOUND") {
             console.error("No Internet Connection");
         } else {
             console.log("Connected");


### PR DESCRIPTION
DNS resolution has been done using (nodejs) "dns.resolve" method, which, for some unknown reason has started returning "REFUSED" errors, on some Windows systems. An alternative method "dns.lookup" method offers a similar functionality using native system utilities. But has some drawbacks - invokes blocking calls and caches resolved addresses. Neither of these, however, apply to El-MAVEN since, we spawn fresh subprocesses for every polly-cli method.