### PR TITLE
[Add] Add workspace v2 API to retrieve user projects in El-MAVEN

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -711,6 +711,31 @@ module.exports.get_Project_names = function (token_filename) {
     });
 }
 
+module.exports.getProjectNamesV2 = function (cookie, next) {
+    var url = 'https://v2.api.devpolly.elucidata.io' + next;
+    var options = {
+        method: 'GET',
+        url: url,
+        headers:
+            {
+                'content-type': 'application/vnd.api+json',
+                'cookie': cookie                
+            },
+        json: true
+    };
+
+    request(options, function (error, response, body) {
+        if (error) throw new Error(chalk.bold.red(error));
+        console.log(chalk.yellow.bgBlack.bold(`PostRun Response: `));
+        if (response.statusCode != 200) {
+            console.error(JSON.stringify(response.body));
+            return;
+        }
+        console.log(chalk.green.bold(JSON.stringify(body)));
+        return body
+    });
+}
+
 module.exports.get_organizational_databases = function (token_filename,organization) {
     if (has_id_token(token_filename)) {
         public_token_header = read_id_token(token_filename);

--- a/prod/index.js
+++ b/prod/index.js
@@ -712,6 +712,31 @@ module.exports.get_Project_names = function (token_filename) {
     });
 }
 
+module.exports.getProjectNamesV2 = function (cookie, next) {
+    var url = 'https://v2.api.polly.elucidata.io' + next;
+    var options = {
+        method: 'GET',
+        url: url,
+        headers:
+            {
+                'content-type': 'application/vnd.api+json',
+                'cookie': cookie                
+            },
+        json: true
+    };
+
+    request(options, function (error, response, body) {
+        if (error) throw new Error(chalk.bold.red(error));
+        console.log(chalk.yellow.bgBlack.bold(`PostRun Response: `));
+        if (response.statusCode != 200) {
+            console.error(JSON.stringify(response.body));
+            return;
+        }
+        console.log(chalk.green.bold(JSON.stringify(body)));
+        return body
+    });
+}
+
 module.exports.get_organizational_databases = function (token_filename,organization) {
     if (has_id_token(token_filename)) {
         public_token_header = read_id_token(token_filename);

--- a/test/index.js
+++ b/test/index.js
@@ -712,6 +712,31 @@ module.exports.get_Project_names = function (token_filename) {
     });
 }
 
+module.exports.getProjectNamesV2 = function (cookie, next) {
+    var url = 'https://v2.api.testpolly.elucidata.io' + next;
+    var options = {
+        method: 'GET',
+        url: url,
+        headers:
+            {
+                'content-type': 'application/vnd.api+json',
+                'cookie': cookie                
+            },
+        json: true
+    };
+
+    request(options, function (error, response, body) {
+        if (error) throw new Error(chalk.bold.red(error));
+        console.log(chalk.yellow.bgBlack.bold(`PostRun Response: `));
+        if (response.statusCode != 200) {
+            console.error(JSON.stringify(response.body));
+            return;
+        }
+        console.log(chalk.green.bold(JSON.stringify(body)));
+        return body
+    });
+}
+
 module.exports.get_organizational_databases = function (token_filename,organization) {
     if (has_id_token(token_filename)) {
         public_token_header = read_id_token(token_filename);


### PR DESCRIPTION
This PR is for the following issue - 

Retrieving projects through the EPI dialog of El-MAVEN gives a timeout when the number of projects is above 100. As the API which was being used was V1 and doesn't implement pagination. 

A new function has been created to get projects using V2 API. 

P.S- The earlier function shouldn't be edited for the above implementation as it would lead to a crash in earlier versions of El-MAVEN. 